### PR TITLE
添加群管理、群消息功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div style="width: auto; margin: auto;">
 
 ![botpy](https://socialify.git.ci/tencent-connect/botpy/image?description=1&font=Source%20Code%20Pro&forks=1&issues=1&language=1&logo=https%3A%2F%2Fgithub.com%2Ftencent-connect%2Fbot-docs%2Fblob%2Fmain%2Fdocs%2F.vuepress%2Fpublic%2Ffavicon-64px.png%3Fraw%3Dtrue&owner=1&pattern=Circuit%20Board&pulls=1&stargazers=1&theme=Light)
 
@@ -35,6 +35,7 @@ pip install qq-botpy
 需要使用的地方`import botpy`
 
 ```python
+# noinspection PyUnresolvedReferences
 import botpy
 ```
 
@@ -110,7 +111,7 @@ class MyClient(botpy.Client):
 
 ## 示例机器人
 
-[`examples`](./examples/) 目录下存放示例机器人，具体使用可参考[`Readme.md`](./examples/README.md) 
+[`examples`](./examples) 目录下存放示例机器人，具体使用可参考[`Readme.md`](./examples/README.md) 
 
     examples/
     .
@@ -167,7 +168,7 @@ pytest
 感谢感谢以下开发者对 `botpy` 作出的贡献：
 
 <a href="https://github.com/tencent-connect/botpy/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tencent-connect/botpy" />
+  <img src="https://contrib.rocks/image?repo=tencent-connect/botpy"  alt="img"/>
 </a>
 
 # 加入官方社区

--- a/botpy/api.py
+++ b/botpy/api.py
@@ -120,11 +120,11 @@ class BotAPI:
         return await self._http.request(route)
 
     async def create_guild_role_member(
-        self,
-        guild_id: str,
-        role_id: str,
-        user_id: str,
-        channel_id: str = None,
+            self,
+            guild_id: str,
+            role_id: str,
+            user_id: str,
+            channel_id: str = None,
     ) -> str:
         """
         增加频道身份组成员。
@@ -247,8 +247,8 @@ class BotAPI:
             guild_id=guild_id,
         )
         return await self._http.request(route, params=params)
-    
-        async def get_guild_role_members(
+
+    async def get_guild_role_members(
             self, guild_id: str, role_id: str, start_index: str = "0", limit: int = 1
     ) -> Dict[str, Union[List[user.Member], str]]:
         """
@@ -328,7 +328,7 @@ class BotAPI:
         return await self._http.request(route)
 
     async def create_channel(
-        self, guild_id: str, name: str, type: channel.ChannelType, sub_type: channel.ChannelSubType, **fields
+            self, guild_id: str, name: str, _type: channel.ChannelType, sub_type: channel.ChannelSubType, **fields
     ) -> channel.ChannelPayload:
         """
         创建子频道
@@ -336,7 +336,7 @@ class BotAPI:
         Args:
           guild_id (str): 频道 ID。
           name (str): 子频道名。
-          type (channel.ChannelType): 子频道类型
+          _type (channel.ChannelType): 子频道类型
           sub_type (channel.ChannelSubType): 子频道子类型
 
         Kwargs（fields）:
@@ -348,7 +348,7 @@ class BotAPI:
         """
         payload = {
             "name": name,
-            "type": int(type),
+            "type": int(_type),
             "subtype": int(sub_type),
         }
         valid_keys = ("position", "parent_id")
@@ -407,7 +407,7 @@ class BotAPI:
         return await self._http.request(route)
 
     async def update_channel_user_permissions(
-        self, channel_id: str, user_id: str, add: Permission = None, remove: Permission = None
+            self, channel_id: str, user_id: str, add: Permission = None, remove: Permission = None
     ) -> str:
         """
         修改指定子频道用户的权限。
@@ -445,7 +445,7 @@ class BotAPI:
         return await self._http.request(route)
 
     async def update_channel_role_permissions(
-        self, channel_id: str, role_id: str, add: Permission = None, remove: Permission = None
+            self, channel_id: str, role_id: str, add: Permission = None, remove: Permission = None
     ) -> str:
         """
         修改指定子频道身份组的权限
@@ -459,7 +459,7 @@ class BotAPI:
         Returns:
           成功执行返回`None`。
         """
-        payload = {"add": str(add.value)  if add else None, "remove": str(remove.value)  if remove else None}
+        payload = {"add": str(add.value) if add else None, "remove": str(remove.value) if remove else None}
 
         route = Route(
             "PUT", "/channels/{channel_id}/roles/{role_id}/permissions", channel_id=channel_id, role_id=role_id
@@ -484,18 +484,18 @@ class BotAPI:
         return await self._http.request(route)
 
     async def post_message(
-        self,
-        channel_id: str,
-        content: str = None,
-        embed: message.Embed = None,
-        ark: message.Ark = None,
-        message_reference: message.Reference = None,
-        image: str = None,
-        file_image: Union[bytes, BinaryIO, str] = None,
-        msg_id: str = None,
-        event_id: str = None,
-        markdown: message.MarkdownPayload = None,
-        keyboard: message.Keyboard = None,
+            self,
+            channel_id: str,
+            content: str = None,
+            embed: message.Embed = None,
+            ark: message.Ark = None,
+            message_reference: message.Reference = None,
+            image: str = None,
+            file_image: Union[bytes, BinaryIO, str] = None,
+            msg_id: str = None,
+            event_id: str = None,
+            markdown: message.MarkdownPayload = None,
+            keyboard: message.Keyboard = None,
     ) -> message.Message:
         """
         发送消息。
@@ -561,10 +561,10 @@ class BotAPI:
         return await self._http.request(route, params=params)
 
     async def post_keyboard_message(
-        self,
-        channel_id: str,
-        keyboard: message.KeyboardPayload = None,
-        markdown: message.MarkdownPayload = None,
+            self,
+            channel_id: str,
+            keyboard: message.KeyboardPayload = None,
+            markdown: message.MarkdownPayload = None,
     ) -> message.Message:
         """
         `post_keyboard_message` 使用内联键盘发送消息
@@ -604,18 +604,18 @@ class BotAPI:
         return await self._http.request(route, json=payload)
 
     async def post_dms(
-        self,
-        guild_id: str,
-        content: str = None,
-        embed: message.Embed = None,
-        ark: message.Ark = None,
-        message_reference: message.Reference = None,
-        image: str = None,
-        file_image: Union[bytes, BinaryIO, str] = None,
-        msg_id: str = None,
-        event_id: str = None,
-        markdown: message.MarkdownPayload = None,
-        keyboard: message.Keyboard = None,
+            self,
+            guild_id: str,
+            content: str = None,
+            embed: message.Embed = None,
+            ark: message.Ark = None,
+            message_reference: message.Reference = None,
+            image: str = None,
+            file_image: Union[bytes, BinaryIO, str] = None,
+            msg_id: str = None,
+            event_id: str = None,
+            markdown: message.MarkdownPayload = None,
+            keyboard: message.Keyboard = None,
     ) -> message.Message:
         """
         发送私信。
@@ -790,7 +790,7 @@ class BotAPI:
         return await self._http.request(route, json=payload)
 
     async def mute_member(
-        self, guild_id: str, user_id: str, mute_end_timestamp: str = None, mute_seconds: str = None
+            self, guild_id: str, user_id: str, mute_end_timestamp: str = None, mute_seconds: str = None
     ) -> str:
         """
         使频道中的指定成员禁言。
@@ -815,7 +815,7 @@ class BotAPI:
         return await self._http.request(route, json=payload)
 
     async def mute_multi_member(
-        self, guild_id: str, user_ids: List[str], mute_end_timestamp: str = None, mute_seconds: str = None
+            self, guild_id: str, user_ids: List[str], mute_end_timestamp: str = None, mute_seconds: str = None
     ) -> str:
         """
         使频道中的多个成员禁言
@@ -875,7 +875,8 @@ class BotAPI:
         return await self._http.request(route, json=payload)
 
     async def create_recommend_announce(
-        self, guild_id: str, announces_type: announce.AnnouncesType, recommend_channels: List[announce.RecommendChannel]
+            self, guild_id: str, announces_type: announce.AnnouncesType,
+            recommend_channels: List[announce.RecommendChannel]
     ) -> announce.Announce:
         """
         创建推荐子频道类型的频道公告
@@ -931,7 +932,7 @@ class BotAPI:
         return data["apis"]
 
     async def post_permission_demand(
-        self, guild_id: str, channel_id: str, api_identify: permission.APIPermissionDemandIdentify, desc: str
+            self, guild_id: str, channel_id: str, api_identify: permission.APIPermissionDemandIdentify, desc: str
     ) -> permission.APIPermissionDemand:
         """
         用于创建 API 接口权限授权链接，该链接指向guild_id对应的频道
@@ -984,13 +985,13 @@ class BotAPI:
         return await self._http.request(route)
 
     async def create_schedule(
-        self,
-        channel_id: str,
-        name: str,
-        start_timestamp: str,
-        end_timestamp: str,
-        jump_channel_id: str,
-        remind_type: schedule.RemindType,
+            self,
+            channel_id: str,
+            name: str,
+            start_timestamp: str,
+            end_timestamp: str,
+            jump_channel_id: str,
+            remind_type: schedule.RemindType,
     ) -> schedule.Schedule:
         """
         用于在日程子频道创建一个日程。
@@ -1029,14 +1030,14 @@ class BotAPI:
         return await self._http.request(route, json=payload)
 
     async def update_schedule(
-        self,
-        channel_id: str,
-        schedule_id: str,
-        name: str,
-        start_timestamp: str,
-        end_timestamp: str,
-        jump_channel_id: str,
-        remind_type: schedule.RemindType,
+            self,
+            channel_id: str,
+            schedule_id: str,
+            name: str,
+            start_timestamp: str,
+            end_timestamp: str,
+            jump_channel_id: str,
+            remind_type: schedule.RemindType,
     ) -> schedule.Schedule:
         """
         修改日程。
@@ -1141,13 +1142,13 @@ class BotAPI:
         return await self._http.request(route)
 
     async def get_reaction_users(
-        self,
-        channel_id: str,
-        message_id: str,
-        emoji_type: emoji.EmojiType,
-        emoji_id: str,
-        cookie: str = None,
-        limit: int = 20,
+            self,
+            channel_id: str,
+            message_id: str,
+            emoji_type: emoji.EmojiType,
+            emoji_id: str,
+            cookie: str = None,
+            limit: int = 20,
     ) -> reaction.ReactionUsers:
         """
         获取表情表态用户列表
@@ -1276,7 +1277,8 @@ class BotAPI:
         )
         return await self._http.request(route)
 
-    async def post_thread(self, channel_id: str, title: str, content: str, format: forum.Format) -> forum.PostThreadRsp:
+    async def post_thread(self, channel_id: str, title: str, content: str,
+                          _format: forum.Format) -> forum.PostThreadRsp:
         """
         该接口用于发表帖子。
 
@@ -1284,7 +1286,7 @@ class BotAPI:
           channel_id (str): 子频道 ID。
           title (str): 线程的标题。
           content (str): 帖子的内容。
-          format (forum.Format): 内容的格式。
+          _format (forum.Format): 内容的格式。
 
         Returns:
           返回PostThreadRsp 对象。
@@ -1295,7 +1297,7 @@ class BotAPI:
             channel_id=channel_id,
         )
 
-        payload = {"title": title, "content": content, "format": format}
+        payload = {"title": title, "content": content, "format": _format}
         return await self._http.request(route, json=payload)
 
     async def delete_thread(self, channel_id: str, thread_id: str) -> str:
@@ -1313,3 +1315,83 @@ class BotAPI:
             "DELETE", "/channels/{channel_id}/threads/{thread_id}", channel_id=channel_id, thread_id=thread_id
         )
         return await self._http.request(route)
+
+    async def post_user_messages(self, user_id: str, content: str = ' ', msg_type: int = 0, markdown: dict = None,
+                                 keyboard: dict = None, media: dict = None, ark: dict = None,
+                                 msg_id: str = None, msg_seq: int = 1) -> dict:
+        """
+        发送消息到私聊
+
+        Args:
+          user_id (str): 用户的 openid。
+          content (str): 文本内容。
+          msg_type (int): 消息类型（0: 文本，1: 图文混排，2: markdown，3: ark 消息，4: embed，7: media 富媒体）。
+          markdown (dict, optional): markdown 格式的消息内容。
+          keyboard (dict, optional): 消息交互的消息按钮。
+          media (dict, optional): 富媒体消息内容。
+          ark (dict, optional): ark 格式的消息内容。
+          msg_id (str, optional): 前置收到的用户发送过来的消息 ID，用于发送被动消息（回复）。
+          msg_seq (int, optional): 回复消息的序号，与 msg_id 联合使用，默认为 1。
+
+        Returns:
+          dict: 返回包含消息唯一 ID 和发送时间的字典。
+        """
+        payload = {
+            "content": content,
+            "msg_type": msg_type,
+        }
+        if markdown:
+            payload["markdown"] = markdown
+        if keyboard:
+            payload["keyboard"] = keyboard
+        if media:
+            payload["media"] = media
+        if ark:
+            payload["ark"] = ark
+
+        if msg_id:
+            payload["msg_id"] = msg_id
+            payload["msg_seq"] = msg_seq
+
+        route = Route("POST", "/v2/users/{user_id}/messages", user_id=user_id)
+        return await self._http.request(route, json=payload)
+
+    async def post_group_messages(self, group_openid: str, content: str = ' ', msg_type: int = 0, markdown: dict = None,
+                                  keyboard: dict = None, media: dict = None, ark: dict = None,
+                                  msg_id: str = None, msg_seq: int = 1) -> dict:
+        """
+        发送消息到群聊
+
+        Args:
+          group_openid (str): 群聊的 openid。
+          content (str): 文本内容。
+          msg_type (int): 消息类型（0: 文本，1: 图文混排，2: markdown，3: ark 消息，4: embed，7: media 富媒体）。
+          markdown (dict, optional): markdown 格式的消息内容。
+          keyboard (dict, optional): 消息交互的消息按钮。
+          media (dict, optional): 富媒体消息内容。
+          ark (dict, optional): ark 格式的消息内容。
+          msg_id (str, optional): 前置收到的用户发送过来的消息 ID，用于发送被动消息（回复）。
+          msg_seq (int, optional): 回复消息的序号，与 msg_id 联合使用，默认为 1。
+
+        Returns:
+          dict: 返回包含消息唯一 ID 和发送时间的字典。
+        """
+        payload = {
+            "content": content,
+            "msg_type": msg_type,
+        }
+        if markdown:
+            payload["markdown"] = markdown
+        if keyboard:
+            payload["keyboard"] = keyboard
+        if media:
+            payload["media"] = media
+        if ark:
+            payload["ark"] = ark
+
+        if msg_id:
+            payload["msg_id"] = msg_id
+            payload["msg_seq"] = msg_seq
+
+        route = Route("POST", "/v2/groups/{group_openid}/messages", group_openid=group_openid)
+        return await self._http.request(route, json=payload)

--- a/botpy/api.py
+++ b/botpy/api.py
@@ -22,6 +22,7 @@ from .types import (
     forum,
 )
 
+
 class BotAPI:
     """
     机器人相关的API接口类
@@ -1418,6 +1419,7 @@ class BotAPI:
         上传/发送群聊图片
 
         Args:
+          group_openid (str): 您要将消息发送到的群的 ID
           file_type (int): 媒体类型：1 图片png/jpg，2 视频mp4，3 语音silk，4 文件（暂不开放）
           url (str): 需要发送媒体资源的url
           srv_send_msg (bool): 设置 true 会直接发送消息到目标端，且会占用主动消息频次
@@ -1438,6 +1440,7 @@ class BotAPI:
         上传/发送c2c图片
 
         Args:
+          openid (str): 您要将消息发送到的用户的 ID
           file_type (int): 媒体类型：1 图片png/jpg，2 视频mp4，3 语音silk，4 文件（暂不开放）
           url (str): 需要发送媒体资源的url
           srv_send_msg (bool): 设置 true 会直接发送消息到目标端，且会占用主动消息频次

--- a/botpy/client.py
+++ b/botpy/client.py
@@ -79,7 +79,7 @@ class Client:
         self,
         exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        _traceback: Optional[TracebackType],
     ) -> None:
         _log.debug("[botpy] 机器人客户端: __aexit__")
 
@@ -103,6 +103,7 @@ class Client:
     def is_closed(self) -> bool:
         return self._closed
 
+    # noinspection PyMethodMayBeStatic,PyUnusedLocal
     async def on_error(self, event_method: str, *args: Any, **kwargs: Any) -> None:
         traceback.print_exc()
 
@@ -252,7 +253,7 @@ class Client:
         try:
             coro = getattr(self, method)
         except AttributeError:
-            pass
+            _log.debug("[botpy] 事件: %s 未注册", event)
         else:
             self._schedule_event(coro, method, *args, **kwargs)
 

--- a/botpy/connection.py
+++ b/botpy/connection.py
@@ -5,7 +5,7 @@ from typing import List, Callable, Dict, Any, Optional
 from .channel import Channel
 from .guild import Guild
 from .interaction import Interaction
-from .message import Message, DirectMessage, MessageAudit
+from .message import Message, DirectMessage, MessageAudit, MessageGroup
 from .user import Member
 from .reaction import Reaction
 from .audio import Audio, PublicAudio
@@ -65,8 +65,8 @@ class ConnectionSession:
 
         await asyncio.wait(tasks)
 
-    async def _runner(self, session, time_interval):
-        await self._connect(session)
+    async def _runner(self, _session, time_interval):
+        await self._connect(_session)
         # 后台有频率限制，根据间隔时间发起链接请求
         await asyncio.sleep(time_interval)
 
@@ -89,9 +89,11 @@ class ConnectionState:
         self._dispatch = dispatch
         self.api = api
 
+    # noinspection PyUnusedLocal
     def parse_ready(self, payload):
         self._dispatch("ready")
 
+    # noinspection PyUnusedLocal
     def parse_resumed(self, payload):
         self._dispatch("resumed")
 
@@ -263,3 +265,24 @@ class ConnectionState:
     def parse_open_forum_reply_delete(self, payload):
         _forum = OpenThread(self.api, payload.get('d', {}))
         self._dispatch("open_forum_reply_delete", payload.get('d', {}))
+
+    # botpy.flags.Intents.group_manage
+    def parse_group_add_robot(self, payload):
+        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_add_robot", _message)
+
+    def parse_group_del_robot(self, payload):
+        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_del_robot", _message)
+
+    def parse_group_msg_reject(self, payload):
+        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_msg_reject", _message)
+
+    def parse_group_msg_receive(self, payload):
+        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_msg_receive", _message)
+
+    def parse_group_at_message_create(self, payload):
+        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_at_message_create", _message)

--- a/botpy/connection.py
+++ b/botpy/connection.py
@@ -27,12 +27,12 @@ class ConnectionSession:
     """
 
     def __init__(
-        self,
-        max_async,
-        connect: Callable,
-        dispatch: Callable,
-        loop=None,
-        api: BotAPI = None,
+            self,
+            max_async,
+            connect: Callable,
+            dispatch: Callable,
+            loop=None,
+            api: BotAPI = None,
     ):
         self.dispatch = dispatch
         self.state = ConnectionState(dispatch, api)
@@ -202,7 +202,7 @@ class ConnectionState:
         _message = Message(self.api, payload.get('id', None), payload.get('d', {}))
         self._dispatch("public_message_delete", _message)
 
-     # botpy.flags.Intents.public_messages
+    # botpy.flags.Intents.public_messages
     def parse_group_at_message_create(self, payload):
         _message = GroupMessage(self.api, payload.get("id", None), payload.get("d", {}))
         self._dispatch("group_at_message_create", _message)
@@ -210,6 +210,22 @@ class ConnectionState:
     def parse_c2c_message_create(self, payload):
         _message = C2CMessage(self.api, payload.get("id", None), payload.get("d", {}))
         self._dispatch("c2c_message_create", _message)
+
+    def parse_group_add_robot(self, payload):
+        _message = GroupMessage(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_add_robot", _message)
+
+    def parse_group_del_robot(self, payload):
+        _message = GroupMessage(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_del_robot", _message)
+
+    def parse_group_msg_reject(self, payload):
+        _message = GroupMessage(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_msg_reject", _message)
+
+    def parse_group_msg_receive(self, payload):
+        _message = GroupMessage(self.api, payload.get('id', None), payload.get('d', {}))
+        self._dispatch("group_msg_receive", _message)
 
     # botpy.flags.Intents.forums
     def parse_forum_thread_create(self, payload):
@@ -274,24 +290,3 @@ class ConnectionState:
     def parse_open_forum_reply_delete(self, payload):
         _forum = OpenThread(self.api, payload.get('d', {}))
         self._dispatch("open_forum_reply_delete", payload.get('d', {}))
-
-    # botpy.flags.Intents.group_manage
-    def parse_group_add_robot(self, payload):
-        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
-        self._dispatch("group_add_robot", _message)
-
-    def parse_group_del_robot(self, payload):
-        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
-        self._dispatch("group_del_robot", _message)
-
-    def parse_group_msg_reject(self, payload):
-        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
-        self._dispatch("group_msg_reject", _message)
-
-    def parse_group_msg_receive(self, payload):
-        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
-        self._dispatch("group_msg_receive", _message)
-
-    def parse_group_at_message_create(self, payload):
-        _message = MessageGroup(self.api, payload.get('id', None), payload.get('d', {}))
-        self._dispatch("group_at_message_create", _message)

--- a/botpy/flags.py
+++ b/botpy/flags.py
@@ -234,19 +234,6 @@ class Intents(BaseFlags):
         return 1 << 12
 
     @Flag
-    def group_manage(self):
-        """:class:`bool`: 是否打开群管理事件的监听.
-
-        - :func:`group_add_robot`: 机器人加入群聊
-        - :func:`group_del_robot`: 机器人退出群聊
-        - :func:`group_msg_reject`: 群聊拒绝机器人主动消息
-        - :func:`group_msg_receive`: 群聊接受机器人主动消息
-        - :func:`group_at_message_create`: 当收到@机器人的消息时
-
-        """
-        return 1 << 25
-
-    @Flag
     def interaction(self):
         """:class:`bool`: 是否打开互动事件的监听.
 
@@ -343,9 +330,14 @@ class Intents(BaseFlags):
 
         - :func:`on_group_at_message_create`            // 当收到群@机器人的消息时
         - :func:`on_c2c_message_create`                 // 当收到c2c的消息时
+        - :func:`group_add_robot`                       //机器人加入群聊
+        - :func:`group_del_robot`                       //机器人退出群聊
+        - :func:`group_msg_reject`                      //群聊拒绝机器人主动消息
+        - :func:`group_msg_receive`                     //群聊接受机器人主动消息
 
         """
         return 1 << 25
+
 
 @fill_with_flags()
 class Permission(BaseFlags):

--- a/botpy/flags.py
+++ b/botpy/flags.py
@@ -114,6 +114,7 @@ class Intents(BaseFlags):
     message_audit	消息审核事件
     forums	论坛事件 (仅 私域 机器人能够设置此 intents)
     audio_action	音频事件
+    group_manage	群管理事件
     """
 
     __slots__ = ()
@@ -126,6 +127,7 @@ class Intents(BaseFlags):
                 raise TypeError(f"{key!r} is not a valid flag name.")
             setattr(self, key, value)
 
+    # noinspection PyUnresolvedReferences,PyDunderSlots
     @classmethod
     def all(cls):
         """打开所有事件的监听"""
@@ -142,6 +144,7 @@ class Intents(BaseFlags):
         self.public_guild_messages = True
         self.audio_or_live_channel_member = True
         self.open_forum_event = True
+        self.group_manage = True
         return self
 
     @classmethod
@@ -151,6 +154,7 @@ class Intents(BaseFlags):
         self.value = self.DEFAULT_VALUE
         return self
 
+    # noinspection PyUnresolvedReferences,PyDunderSlots
     @classmethod
     def default(cls):
         """打开所有公域事件的监听
@@ -226,6 +230,19 @@ class Intents(BaseFlags):
 
         """
         return 1 << 12
+
+    @Flag
+    def group_manage(self):
+        """:class:`bool`: 是否打开群管理事件的监听.
+
+        - :func:`group_add_robot`: 机器人加入群聊
+        - :func:`group_del_robot`: 机器人退出群聊
+        - :func:`group_msg_reject`: 群聊拒绝机器人主动消息
+        - :func:`group_msg_receive`: 群聊接受机器人主动消息
+        - :func:`group_at_message_create`: 当收到@机器人的消息时
+
+        """
+        return 1 << 25
 
     @Flag
     def interaction(self):

--- a/botpy/message.py
+++ b/botpy/message.py
@@ -196,28 +196,16 @@ class BaseMessage:
         "attachments",
         "msg_seq",
         "timestamp",
-        "event_id"
+        "event_id",
+        "author",
+        "group_openid",
+        "op_member_openid"
     )
-    
-    def __init__(self, api: BotAPI, event_id, data: gateway.MessageGroupPayload):
-        self._api = api
-
-        self.author = self._User(data.get("author", {}))
-        self.content = data.get("content", None)
-        self.group_openid = data.get("group_openid", None)
-        self.op_member_openid = data.get("op_member_openid", None)
-        self.id = data.get("id", None)
-        self.timestamp = data.get("timestamp", None)
-
-        self.event_id = event_id
-
-    def __repr__(self):
-        return str({items: str(getattr(self, items)) for items in self.__slots__ if not items.startswith('_')})
 
     class _User:
         def __init__(self, data):
             self.member_openid = data.get("member_openid", None)
-            
+
     def __init__(self, api: BotAPI, event_id, data: gateway.MessagePayload):
         self._api = api
         self.id = data.get("id", None)
@@ -251,6 +239,7 @@ class BaseMessage:
 
         def __repr__(self):
             return str(self.__dict__)
+
         
 class GroupMessage(BaseMessage):
     __slots__ = (
@@ -276,7 +265,8 @@ class GroupMessage(BaseMessage):
 
     async def reply(self, **kwargs):
         return await self._api.post_group_message(group_openid=self.group_openid, msg_id=self.id, **kwargs)
-    
+
+
 class C2CMessage(BaseMessage):
     __slots__ = ("author",)
 

--- a/botpy/message.py
+++ b/botpy/message.py
@@ -184,3 +184,41 @@ class MessageAudit:
 
     def __repr__(self):
         return str({items: str(getattr(self, items)) for items in self.__slots__ if not items.startswith('_')})
+
+
+class MessageGroup:
+    __slots__ = (
+        "_api",
+        "author",
+        "content",
+        "group_openid",
+        "op_member_openid",
+        "id",
+        "timestamp",
+        "event_id"
+    )
+
+    def __init__(self, api: BotAPI, event_id, data: gateway.MessageGroupPayload):
+        self._api = api
+
+        self.author = self._User(data.get("author", {}))
+        self.content = data.get("content", None)
+        self.group_openid = data.get("group_openid", None)
+        self.op_member_openid = data.get("op_member_openid", None)
+        self.id = data.get("id", None)
+        self.timestamp = data.get("timestamp", None)
+
+        self.event_id = event_id
+
+    def __repr__(self):
+        return str({items: str(getattr(self, items)) for items in self.__slots__ if not items.startswith('_')})
+
+    class _User:
+        def __init__(self, data):
+            self.member_openid = data.get("member_openid", None)
+
+        def __repr__(self):
+            return str(self.__dict__)
+
+    async def reply(self, **kwargs):
+        return await self._api.post_group_messages(group_openid=self.group_openid, msg_id=self.id, **kwargs)

--- a/botpy/robot.py
+++ b/botpy/robot.py
@@ -5,6 +5,7 @@ from .logging import get_logger
 
 _log = get_logger()
 
+
 class Robot:
     def __init__(self, data: robot.Robot):
         self._update(data)

--- a/botpy/types/audio.py
+++ b/botpy/types/audio.py
@@ -12,6 +12,7 @@ AudioStatus = Literal[0, 1, 2, 3]
 
 PublicAudioType = Literal[2, 5]
 
+
 class AudioControl(TypedDict):
     audio_url: str
     text: str

--- a/botpy/types/forum.py
+++ b/botpy/types/forum.py
@@ -69,6 +69,7 @@ class PostThreadRsp(TypedDict):
     task_id: str
     create_time: str
 
+
 class OpenForumEvent(TypedDict):
     guild_id: str
     channel_id: str

--- a/botpy/types/gateway.py
+++ b/botpy/types/gateway.py
@@ -53,6 +53,8 @@ class MessagePayload(TypedDict):
     seq: int
     seq_in_channel: str
     timestamp: str
+    msg_seq: int
+    group_openid: str
 
 
 class DirectMessagePayload(TypedDict):
@@ -79,16 +81,3 @@ class MessageAuditPayload(TypedDict):
     audit_time: str
     create_time: str
     seq_in_channel: str
-
-
-class GroupMemberPayload(TypedDict):
-    member_openid: str
-
-
-class MessageGroupPayload(TypedDict):
-    author: GroupMemberPayload
-    content: str
-    group_openid: str
-    op_member_openid: str
-    timestamp: str
-    id: str

--- a/botpy/types/gateway.py
+++ b/botpy/types/gateway.py
@@ -79,3 +79,16 @@ class MessageAuditPayload(TypedDict):
     audit_time: str
     create_time: str
     seq_in_channel: str
+
+
+class GroupMemberPayload(TypedDict):
+    member_openid: str
+
+
+class MessageGroupPayload(TypedDict):
+    author: GroupMemberPayload
+    content: str
+    group_openid: str
+    op_member_openid: str
+    timestamp: str
+    id: str

--- a/botpy/types/message.py
+++ b/botpy/types/message.py
@@ -65,6 +65,7 @@ class KeyboardPayload(TypedDict, total=False):
     id: str
     content: Keyboard
 
+
 class Media(TypedDict):
     file_uuid: str  # 文件ID
     file_info: str  # 文件信息，用于发消息接口的media字段使用

--- a/botpy/types/rich_text.py
+++ b/botpy/types/rich_text.py
@@ -125,4 +125,3 @@ class RichObject(TypedDict):
     url_info: URLInfo
     emoji_info: EmojiInfo
     channel_info: ChannelInfo
-

--- a/docs/事件监听.md
+++ b/docs/事件监听.md
@@ -7,23 +7,24 @@
 - [准备](#准备)
 - [使用方式](#使用方式)
 - [监听的事件](#监听的事件)
-  - [公域消息事件的监听](#公域消息事件的监听)
-  - [消息事件的监听](#消息事件的监听)
-  - [私信事件的监听](#私信事件的监听)
-  - [消息相关互动事件的监听](#消息相关互动事件的监听)
-  - [频道事件的监听](#频道事件的监听)
-  - [频道成员事件的监听](#频道成员事件的监听)
-  - [互动事件的监听](#互动事件的监听)
-  - [消息审核事件的监听](#消息审核事件的监听)
-  - [论坛事件的监听](#论坛事件的监听)
-  - [音频事件的监听](#音频事件的监听)
-  - [音视频/直播子频道成员进出事件](#音视频/直播子频道成员进出事件)
-  - [开放论坛事件对象](#开放论坛事件对象)
+    - [公域消息事件的监听](#公域消息事件的监听)
+    - [消息事件的监听](#消息事件的监听)
+    - [私信事件的监听](#私信事件的监听)
+    - [消息相关互动事件的监听](#消息相关互动事件的监听)
+    - [频道事件的监听](#频道事件的监听)
+    - [频道成员事件的监听](#频道成员事件的监听)
+    - [互动事件的监听](#互动事件的监听)
+    - [消息审核事件的监听](#消息审核事件的监听)
+    - [论坛事件的监听](#论坛事件的监听)
+    - [音频事件的监听](#音频事件的监听)
+    - [音视频/直播子频道成员进出事件](#音视频直播子频道成员进出事件)
+    - [开放论坛事件对象](#开放论坛事件对象)
 - [订阅事件的方法](#订阅事件的方法)
 
 ## 准备
 
 ```python
+# noinspection PyUnresolvedReferences
 import botpy
 ```
 
@@ -34,7 +35,11 @@ import botpy
 在`MyClient`类中调用函数实现处理事件的功能
 
 ```python
+import botpy
+
+
 class MyClient(botpy.Client):
+    ...
 ```
 
 ## 监听的事件
@@ -44,22 +49,29 @@ class MyClient(botpy.Client):
 首先需要订阅事件`public_guild_messages`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(public_guild_messages=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                             | 说明          |
-| ------------------------------------------------ | ----------- |
+|--------------------------------------------------|-------------|
 | on_at_message_create(self, message: Message)     | 当收到@机器人的消息时 |
 | on_public_message_delete(self, message: Message) | 当频道的消息被删除时  |
 
 - **注：需要引入`Message`**
 
 ```python
+import botpy
 from botpy.message import Message
-```
 
-```python
+
 class MyClient(botpy.Client):
     async def on_at_message_create(self, message: Message):
         """
@@ -79,22 +91,29 @@ class MyClient(botpy.Client):
 首先需要订阅事件`guild_messages`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(guild_messages=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                      | 说明                                                             |
-| ----------------------------------------- | -------------------------------------------------------------- |
+|-------------------------------------------|----------------------------------------------------------------|
 | on_message_create(self, message: Message) | 发送消息事件，代表频道内的全部消息，而不只是 at 机器人的消息。</br>内容与 AT_MESSAGE_CREATE 相同 |
 | on_message_delete(self, message: Message) | 删除（撤回）消息事件                                                     |
 
 - **注：需要引入`Message`**
 
 ```python
+import botpy
 from botpy.message import Message
-```
 
-```python
+
 class MyClient(botpy.Client):
     async def on_message_create(self, message: Message):
         """
@@ -112,22 +131,29 @@ class MyClient(botpy.Client):
 首先需要订阅事件`direct_message`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(direct_message=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                                   | 说明               |
-| ------------------------------------------------------ | ---------------- |
+|--------------------------------------------------------|------------------|
 | on_direct_message_create(self, message: DirectMessage) | 当收到用户发给机器人的私信消息时 |
 | on_direct_message_delete(self, message: DirectMessage) | 删除（撤回）消息事件       |
 
 - **注：需要引入`DirectMessage`**
 
 ```python
+import botpy
 from botpy.message import DirectMessage
-```
 
-```python
+
 class MyClient(botpy.Client):
     async def on_direct_message_create(self, message: DirectMessage):
         """
@@ -145,12 +171,19 @@ class MyClient(botpy.Client):
 首先需要订阅事件`guild_message_reactions`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(guild_message_reactions=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                                 | 说明        |
-| ---------------------------------------------------- | --------- |
+|------------------------------------------------------|-----------|
 | on_message_reaction_add(self, reaction: Reaction)    | 为消息添加表情表态 |
 | on_message_reaction_remove(self, reaction: Reaction) | 为消息删除表情表态 |
 
@@ -158,9 +191,9 @@ client = MyClient(intents=intents)
 
 ```python
 from botpy.reaction import Reaction
-```
+import botpy
 
-```python
+
 class MyClient(botpy.Client):
     async def on_message_reaction_add(self, reaction: Reaction):
         """
@@ -178,12 +211,19 @@ class MyClient(botpy.Client):
 首先需要订阅事件`guilds`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(guilds=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                      | 说明            |
-| ----------------------------------------- | ------------- |
+|-------------------------------------------|---------------|
 | on_guild_create(self, guild: Guild)       | 当机器人加入新guild时 |
 | on_guild_update(self, guild: Guild)       | 当guild资料发生变更时 |
 | on_guild_delete(self, guild: Guild)       | 当机器人退出guild时  |
@@ -196,9 +236,9 @@ client = MyClient(intents=intents)
 ```python
 from botpy.guild import Guild
 from botpy.channel import Channel
-```
+import botpy
 
-```python
+
 class MyClient(botpy.Client):
     async def on_guild_create(self, guild: Guild):
         """
@@ -236,12 +276,19 @@ class MyClient(botpy.Client):
 首先需要订阅事件`guild_members`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(guild_members=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                         | 说明       |
-| -------------------------------------------- | -------- |
+|----------------------------------------------|----------|
 | on_guild_member_add(self, member: Member)    | 当成员加入时   |
 | on_guild_member_update(self, member: Member) | 当成员资料变更时 |
 | on_guild_member_remove(self, member: Member) | 当成员被移除时  |
@@ -249,10 +296,10 @@ client = MyClient(intents=intents)
 - **注：需要引入`GuildMember`**
 
 ```python
+import botpy
 from botpy.user import Member
-```
 
-```python
+
 class MyClient(botpy.Client):
     async def on_guild_member_add(self, member: Member):
         """
@@ -275,21 +322,28 @@ class MyClient(botpy.Client):
 首先需要订阅事件`interaction`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(interaction=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                                  | 说明               |
-| ----------------------------------------------------- | ---------------- |
+|-------------------------------------------------------|------------------|
 | on_interaction_create(self, interaction: Interaction) | 当收到用户发给机器人的私信消息时 |
 
 - **注：需要引入`Interaction`**
 
 ```python
 from botpy.interaction import Interaction
-```
+import botpy
 
-```python
+
 class MyClient(botpy.Client):
     async def on_interaction_create(self, interaction: Interaction):
         """
@@ -302,12 +356,19 @@ class MyClient(botpy.Client):
 首先需要订阅事件`message_audit`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(message_audit=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                                 | 说明      |
-| ---------------------------------------------------- | ------- |
+|------------------------------------------------------|---------|
 | on_message_audit_pass(self, message: MessageAudit)   | 消息审核通过  |
 | on_message_audit_reject(self, message: MessageAudit) | 消息审核不通过 |
 
@@ -315,9 +376,9 @@ client = MyClient(intents=intents)
 
 ```python
 from botpy.message import MessageAudit
-```
+import botpy
 
-```python
+
 class MyClient(botpy.Client):
     async def on_message_audit_pass(self, message: MessageAudit):
         """
@@ -337,12 +398,19 @@ class MyClient(botpy.Client):
 首先需要订阅事件`forums`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(forums=True)
 client = MyClient(intents=intents)
 ```
 
 | 对应函数                                                          | 说明         |
-| ------------------------------------------------------------- | ---------- |
+|---------------------------------------------------------------|------------|
 | on_forum_thread_create(self, thread: Thread)                  | 当用户创建主题时   |
 | on_forum_thread_update(self, thread: Thread)                  | 当用户更新主题时   |
 | on_forum_thread_delete(self, thread: Thread)                  | 当用户删除主题时   |
@@ -357,9 +425,9 @@ client = MyClient(intents=intents)
 ```python
 from botpy.forum import Thread
 from botpy.types.forum import Post, Reply, AuditResult
-```
+import botpy
 
-```python
+
 class MyClient(botpy.Client):
     async def on_forum_thread_create(self, thread: Thread):
         """
@@ -407,6 +475,13 @@ class MyClient(botpy.Client):
 首先需要订阅事件`audio_action`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(audio_action=True)
 client = MyClient(intents=intents)
 ```
@@ -422,9 +497,9 @@ client = MyClient(intents=intents)
 
 ```python
 from botpy.audio import Audio
-```
+import botpy
 
-```python
+
 class MyClient(botpy.Client):
     async def on_audio_start(self, audio: Audio):
         """
@@ -437,14 +512,14 @@ class MyClient(botpy.Client):
         """
 
     async def on_audio_on_mic(self, audio: Audio):
-      """
-      此处为处理该事件的代码
-      """
+        """
+        此处为处理该事件的代码
+        """
 
     async def on_audio_off_mic(self, audio: Audio):
-      """
-      此处为处理该事件的代码
-      """
+        """
+        此处为处理该事件的代码
+        """
 ```
 
 ### 音视频/直播子频道成员进出事件
@@ -452,6 +527,13 @@ class MyClient(botpy.Client):
 首先需要订阅事件`audio_or_live_channel_member`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(audio_or_live_channel_member=True)
 client = MyClient(intents=intents)
 ```
@@ -465,19 +547,19 @@ client = MyClient(intents=intents)
 
 ```python
 from botpy.audio import PublicAudio
-```
+import botpy
 
-```python
+
 class MyClient(botpy.Client):
-  async def on_audio_or_live_channel_member_enter(self, Public_Audio: PublicAudio):
-    """
-    此处为处理该事件的代码
-    """
+    async def on_audio_or_live_channel_member_enter(self, public_audio: PublicAudio):
+        """
+        此处为处理该事件的代码
+        """
 
-  async def on_audio_or_live_channel_member_exit(self, Public_Audio: PublicAudio):
-    """
-    此处为处理该事件的代码
-    """
+    async def on_audio_or_live_channel_member_exit(self, public_audio: PublicAudio):
+        """
+        此处为处理该事件的代码
+        """
 ```
 
 ### 开放论坛事件对象
@@ -485,6 +567,13 @@ class MyClient(botpy.Client):
 首先需要订阅事件`open_forum_event`
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents(open_forum_event=True)
 client = MyClient(intents=intents)
 ```
@@ -503,29 +592,29 @@ client = MyClient(intents=intents)
 
 ```python
 from botpy.audio import Audio
-```
+import botpy
 
-```python
+
 class MyClient(botpy.Client):
-  async def on_audio_start(self, audio: Audio):
-    """
-    此处为处理该事件的代码
-    """
+    async def on_audio_start(self, audio: Audio):
+        """
+        此处为处理该事件的代码
+        """
 
-  async def on_audio_finish(self, audio: Audio):
-    """
-    此处为处理该事件的代码
-    """
+    async def on_audio_finish(self, audio: Audio):
+        """
+        此处为处理该事件的代码
+        """
 
-  async def on_audio_on_mic(self, audio: Audio):
-    """
-    此处为处理该事件的代码
-    """
+    async def on_audio_on_mic(self, audio: Audio):
+        """
+        此处为处理该事件的代码
+        """
 
-  async def on_audio_off_mic(self, audio: Audio):
-    """
-    此处为处理该事件的代码
-    """
+    async def on_audio_off_mic(self, audio: Audio):
+        """
+        此处为处理该事件的代码
+        """
 ```
 
 ## 订阅事件的方法
@@ -533,6 +622,13 @@ class MyClient(botpy.Client):
 ### 方法一：
 
 ```python
+import botpy
+
+
+class MyClient(botpy.Client):
+    ...
+
+
 intents = botpy.Intents()
 client = MyClient(intents=intents)
 ```
@@ -542,18 +638,20 @@ client = MyClient(intents=intents)
 例子：
 
 ```python
+import botpy
+
 intents = botpy.Intents(public_guild_messages=True, direct_message=True, guilds=True)
 ```
 
 ### 方法二：
 
+打开对应的订阅([参数列表](#参数列表))
+
 ```python
+import botpy
+
 intents = botpy.Intents.none()
-```
 
-然后打开对应的订阅([参数列表](#参数列表))
-
-```python
 intents.public_guild_messages = True
 intents.direct_message = True
 intents.guilds = True
@@ -563,22 +661,26 @@ intents.guilds = True
 
 方法二对应的快捷订阅方式为
 
-1. 订阅所有事件
+* 订阅所有事件
 
-```python
+```python 
+import botpy
+
 intents = botpy.Intents.all()
-```
+ ```
 
-2. 订阅所有的公域事件
+* 订阅所有的公域事件
 
 ```python
+import botpy
+
 intents = botpy.Intents.default()
 ```
 
 #### 参数列表
 
 | 参数                      | 含义                                 |
-| ----------------------- | ---------------------------------- |
+|-------------------------|------------------------------------|
 | public_guild_messages   | 公域消息事件                             |
 | guild_messages          | 消息事件 **(仅 `私域` 机器人能够设置此 intents)** |
 | direct_message          | 私信事件                               |


### PR DESCRIPTION
在Intents中设置group_manage=True以启用QQ群事件
目前支持：
1. :func:`group_add_robot`: 机器人加入群聊
2. :func:`group_del_robot`: 机器人退出群聊
3. :func:`group_msg_reject`: 群聊拒绝机器人主动消息
4. :func:`group_msg_receive`: 群聊接受机器人主动消息
5. :func:`group_at_message_create`: 当收到@机器人的消息时

消息结构体可使用reply进行回复