### PR TITLE
修复README中示例代码的错误，在新版本中应用secret而不是token

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ class MyClient(botpy.Client):
 
 intents = botpy.Intents(public_guild_messages=True) 
 client = MyClient(intents=intents)
-client.run(appid="12345", token="xxxx")
+client.run(appid="12345", secret="xxxx")
 ```
 
 ### 备注


### PR DESCRIPTION
修复README中示例代码的错误，在新版本中应用secret而不是token